### PR TITLE
Remove postgis, because it requires gdal

### DIFF
--- a/timescale/base.py
+++ b/timescale/base.py
@@ -1,10 +1,6 @@
 import logging
 
-from django.contrib.gis.db.backends.postgis.base import \
-    DatabaseWrapper as PostgisDBWrapper
-
 from django.db import ProgrammingError
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 from . import base_impl

--- a/timescale/base_impl.py
+++ b/timescale/base_impl.py
@@ -1,18 +1,12 @@
 import importlib
 import logging
 
-from django.contrib.gis.db.backends.postgis.base import \
-    DatabaseWrapper as PostgisDBWrapper
-
 from django.db.backends.postgresql.base import (  # isort:skip
     DatabaseWrapper as Psycopg2DatabaseWrapper,
 )
 
-from django.db import ProgrammingError
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-
-from .schema import TimescaleSchemaEditor
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
It seems like postgis requires gdal to use. Because I don't have gdal and because it seems like it requires some extra non-trivial steps to use + timescaledb doesn't actually use postgis I opted to remove postgis. 

So this works for me now. I would suggest that if you introduce postgis you also document what is needed to get going with gdal. 