### PR TITLE
proper migrate to hypertable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ class Metric(TimescaleModel):
 
 ```
 
-If you already have a table and want to just add a field you can add the TimescaleDateTimeField to your model. This also triggers the creation of a hypertable.
+If you already have a table, you can either add `time` field of type `TimescaleDateTimeField` to your model or rename (if not already named `time`) and change type of existing `DateTimeField` (rename first then run `makemigrations` and then change the type, so that `makemigration` considers it as change in same field instead of removing and adding new field). This also triggers the creation of a hypertable.
 
 ```python
 from timescale.db.models.fields import TimescaleDateTimeField
@@ -154,3 +154,4 @@ As such the use of the Django's ORM is perfectally suited to this type of data. 
 
 * [Ben Cleary](https://github.com/bencleary)
 * [Jonathan Sundqvist](https://github.com/jonathan-s)
+* [Harsh Bhikadia](https://github.com/daadu)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ class Metric(TimescaleModel):
 
 ```
 
-If you already have a table, you can either add `time` field of type `TimescaleDateTimeField` to your model or rename (if not already named `time`) and change type of existing `DateTimeField` (rename first then run `makemigrations` and then change the type, so that `makemigration` considers it as change in same field instead of removing and adding new field). This also triggers the creation of a hypertable.
+If you already have a table, you can either add `time` field of type `TimescaleDateTimeField` to your model or rename (if not already named `time`) and change type of existing `DateTimeField` (rename first then run `makemigrations` and then change the type, so that `makemigrations` considers it as change in same field instead of removing and adding new field). This also triggers the creation of a hypertable.
 
 ```python
 from timescale.db.models.fields import TimescaleDateTimeField

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ field of type `TimescaleDateTimeField` to your model or
 rename (if not already named `time`) and change type of
 existing `DateTimeField` (rename first then run
 `makemigrations` and then change the type, so that
-`makemigration` considers it as change in same field
+`makemigrations` considers it as change in same field
 instead of removing and adding new field). This also
 triggers the creation of a hypertable.
 

--- a/README.rst
+++ b/README.rst
@@ -77,9 +77,14 @@ Implementation would look like this
        temperature = models.FloatField()
        
 
-If you already have a table and want to just add a field you can add the
-TimescaleDateTimeField to your model. This also triggers the creation of
-a hypertable.
+If you already have a table, you can either add `time`
+field of type `TimescaleDateTimeField` to your model or
+rename (if not already named `time`) and change type of
+existing `DateTimeField` (rename first then run
+`makemigrations` and then change the type, so that
+`makemigration` considers it as change in same field
+instead of removing and adding new field). This also
+triggers the creation of a hypertable.
 
 .. code:: python
 

--- a/timescale/db/backends/postgis/schema.py
+++ b/timescale/db/backends/postgis/schema.py
@@ -4,18 +4,61 @@ from timescale.db.models.fields import TimescaleDateTimeField
 
 
 class TimescaleSchemaEditor(PostGISSchemaEditor):
+    sql_is_hypertable = 'SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = {table}'
+
+    sql_assert_is_hypertable = (
+            'DO $do$ BEGIN '
+            'IF EXISTS ( '
+            + sql_is_hypertable +
+            ') '
+            'THEN NULL; '
+            'ELSE RAISE EXCEPTION {error_message}; '
+            'END IF;'
+            'END; $do$'
+    )
+    sql_assert_is_not_hypertable = (
+            'DO $do$ BEGIN '
+            'IF EXISTS ( '
+            + sql_is_hypertable +
+            ') '
+            'THEN RAISE EXCEPTION {error_message}; '
+            'ELSE NULL; '
+            'END IF;'
+            'END; $do$'
+    )
+
+    sql_drop_primary_key = 'ALTER TABLE {table} DROP CONSTRAINT {pkey}'
+
     sql_add_hypertable = (
         "SELECT create_hypertable("
         "{table}, {partition_column}, "
-        "chunk_time_interval => interval {interval})"
+        "chunk_time_interval => interval {interval}, "
+        "migrate_data => {migrate})"
     )
 
-    sql_drop_primary_key = (
-        'ALTER TABLE {table} '
-        'DROP CONSTRAINT {pkey}'
-    )
+    sql_set_chunk_time_interval = 'SELECT set_chunk_time_interval({table}, interval {interval})'
 
-    def drop_primary_key(self, model):
+    def _assert_is_hypertable(self, model):
+        """
+        Assert if the table is a hyper table
+        """
+        table = self.quote_value(model._meta.db_table)
+        error_message = self.quote_value("assert failed - " + table + " should be a hyper table")
+
+        sql = self.sql_assert_is_hypertable.format(table=table, error_message=error_message)
+        self.execute(sql)
+
+    def _assert_is_not_hypertable(self, model):
+        """
+        Assert if the table is not a hyper table
+        """
+        table = self.quote_value(model._meta.db_table)
+        error_message = self.quote_value("assert failed - " + table + " should not be a hyper table")
+
+        sql = self.sql_assert_is_not_hypertable.format(table=table, error_message=error_message)
+        self.execute(sql)
+
+    def _drop_primary_key(self, model):
         """
         Hypertables can't partition if the primary key is not
         the partition column.
@@ -29,26 +72,70 @@ class TimescaleSchemaEditor(PostGISSchemaEditor):
 
         self.execute(sql)
 
-    def create_hypertable(self, model, field):
+    def _create_hypertable(self, model, field, should_migrate=False):
         """
         Create the hypertable with the partition column being the field.
         """
+        # assert that the table is not already a hypertable
+        self._assert_is_not_hypertable(model)
+
+        # drop primary key of the table
+        self._drop_primary_key(model)
+
         partition_column = self.quote_value(field.column)
         interval = self.quote_value(field.interval)
         table = self.quote_value(model._meta.db_table)
+        migrate = "true" if should_migrate else "false"
 
-        sql = self.sql_add_hypertable.format(
-            table=table, partition_column=partition_column, interval=interval
-        )
+        if should_migrate and getattr(settings, "TIMESCALE_MIGRATE_HYPERTABLE_WITH_FRESH_TABLE", False):
+            # TODO migrate with fresh table [https://github.com/schlunsen/django-timescaledb/issues/16]
+            raise NotImplementedError()
+        else:
+            sql = self.sql_add_hypertable.format(
+                table=table, partition_column=partition_column, interval=interval, migrate=migrate
+            )
+            self.execute(sql)
 
+    def _set_chunk_time_interval(self, model, field):
+        """
+        Change time interval for hypertable
+        """
+        # assert if already a hypertable
+        self._assert_is_hypertable(model)
+
+        table = self.quote_value(model._meta.db_table)
+        interval = self.quote_value(field.interval)
+
+        sql = self.sql_set_chunk_time_interval.format(table=table, interval=interval)
         self.execute(sql)
 
     def create_model(self, model):
         super().create_model(model)
 
+        # scan if any field is of instance `TimescaleDateTimeField`
         for field in model._meta.local_fields:
-            if not isinstance(field, TimescaleDateTimeField):
-                continue
+            if isinstance(field, TimescaleDateTimeField):
+                # create hypertable, with the field as partition column
+                self._create_hypertable(model, field)
+                break
 
-            self.drop_primary_key(model)
-            self.create_hypertable(model, field)
+    def add_field(self, model, field):
+        super().add_field(model, field)
+
+        # check if this field is type `TimescaleDateTimeField`
+        if isinstance(field, TimescaleDateTimeField):
+            # migrate existing table to hypertable
+            self._create_hypertable(model, field, True)
+
+    def alter_field(self, model, old_field, new_field, strict=False):
+        super().alter_field(model, old_field, new_field, strict)
+
+        #  check if old_field is not type `TimescaleDateTimeField` and new_field is
+        if not isinstance(old_field, TimescaleDateTimeField) and isinstance(new_field, TimescaleDateTimeField):
+            # migrate existing table to hypertable
+            self._create_hypertable(model, new_field, True)
+        # check if old_field and new_field is type `TimescaleDateTimeField` and `interval` is changed
+        elif isinstance(old_field, TimescaleDateTimeField) and isinstance(new_field, TimescaleDateTimeField) \
+                and old_field.interval != new_field.interval:
+            # change chunk-size
+            self._set_chunk_time_interval(model, new_field)

--- a/timescale/db/backends/postgresql/schema.py
+++ b/timescale/db/backends/postgresql/schema.py
@@ -1,21 +1,45 @@
-from django.contrib.gis.db.backends.postgis.schema import PostGISSchemaEditor
+from django.conf import settings
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 
 from timescale.db.models.fields import TimescaleDateTimeField
 
 
-class TimescaleSchemaEditor(PostGISSchemaEditor):
+class TimescaleSchemaEditor(DatabaseSchemaEditor):
+    sql_is_hypertable = 'SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = {table}'
+
+    sql_assert_is_hypertable = (
+            'DO $do$ BEGIN '
+            'IF EXISTS ( '
+            + sql_is_hypertable +
+            ') '
+            'THEN NULL; '
+            'ELSE RAISE EXCEPTION {error_message}; '
+            'END IF;'
+            'END; $do$'
+    )
+    sql_assert_is_not_hypertable = (
+            'DO $do$ BEGIN '
+            'IF EXISTS ( '
+            + sql_is_hypertable +
+            ') '
+            'THEN RAISE EXCEPTION {error_message}; '
+            'ELSE NULL; '
+            'END IF;'
+            'END; $do$'
+    )
+
+    sql_drop_primary_key = 'ALTER TABLE {table} DROP CONSTRAINT {pkey}'
+
     sql_add_hypertable = (
         "SELECT create_hypertable("
         "{table}, {partition_column}, "
-        "chunk_time_interval => interval {interval})"
+        "chunk_time_interval => interval {interval}, "
+        "migrate_data => {migrate})"
     )
 
-    sql_drop_primary_key = (
-        'ALTER TABLE {table} '
-        'DROP CONSTRAINT {pkey}'
-    )
+    sql_set_chunk_time_interval = 'SELECT set_chunk_time_interval({table}, interval {interval})'
 
-    def drop_primary_key(self, model):
+    def _drop_primary_key(self, model):
         """
         Hypertables can't partition if the primary key is not
         the partition column.
@@ -29,26 +53,89 @@ class TimescaleSchemaEditor(PostGISSchemaEditor):
 
         self.execute(sql)
 
-    def create_hypertable(self, model, field):
+    def _create_hypertable(self, model, field, should_migrate=False):
         """
         Create the hypertable with the partition column being the field.
         """
+        # assert that the table is not already a hypertable
+        self._assert_is_not_hypertable(model)
+
+        # drop primary key of the table
+        self._drop_primary_key(model)
+
         partition_column = self.quote_value(field.column)
         interval = self.quote_value(field.interval)
         table = self.quote_value(model._meta.db_table)
+        migrate = "true" if should_migrate else "false"
 
-        sql = self.sql_add_hypertable.format(
-            table=table, partition_column=partition_column, interval=interval
-        )
+        if should_migrate and getattr(settings, "TIMESCALE_MIGRATE_HYPERTABLE_WITH_FRESH_TABLE", False):
+            # TODO migrate with fresh table [https://docs.timescale.com/latest/getting-started/migrating-data#same-db]
+            raise NotImplementedError()
+        else:
+            sql = self.sql_add_hypertable.format(
+                table=table, partition_column=partition_column, interval=interval, migrate=migrate
+            )
+            self.execute(sql)
 
+    def _assert_is_hypertable(self, model):
+        """
+        Assert if the table is a hyper table
+        """
+        table = self.quote_value(model._meta.db_table)
+        error_message = self.quote_value("assert failed - " + table + " should be a hyper table")
+
+        sql = self.sql_assert_is_hypertable.format(table=table, error_message=error_message)
+        self.execute(sql)
+
+    def _assert_is_not_hypertable(self, model):
+        """
+        Assert if the table is not a hyper table
+        """
+        table = self.quote_value(model._meta.db_table)
+        error_message = self.quote_value("assert failed - " + table + " should not be a hyper table")
+
+        sql = self.sql_assert_is_not_hypertable.format(table=table, error_message=error_message)
+        self.execute(sql)
+
+    def _set_chunk_time_interval(self, model, field):
+        """
+        Change time interval for hypertable
+        """
+        # assert if already a hypertable
+        self._assert_is_hypertable(model)
+
+        table = self.quote_value(model._meta.db_table)
+        interval = self.quote_value(field.interval)
+
+        sql = self.sql_set_chunk_time_interval.format(table=table, interval=interval)
         self.execute(sql)
 
     def create_model(self, model):
         super().create_model(model)
 
+        # scan if any field is of instance `TimescaleDateTimeField`
         for field in model._meta.local_fields:
-            if not isinstance(field, TimescaleDateTimeField):
-                continue
+            if isinstance(field, TimescaleDateTimeField):
+                # create hypertable, with the field as partition column
+                self._create_hypertable(model, field)
+                break
 
-            self.drop_primary_key(model)
-            self.create_hypertable(model, field)
+    def add_field(self, model, field):
+        super().add_field(model, field)
+
+        # check if this field is type `TimescaleDateTimeField`
+        if isinstance(field, TimescaleDateTimeField):
+            # migrate existing table to hypertable
+            self._create_hypertable(model, field, True)
+
+    def alter_field(self, model, old_field, new_field, strict=False):
+        super().alter_field(model, old_field, new_field, strict)
+
+        #  check if old_field is not type `TimescaleDateTimeField` and new_field is
+        if not isinstance(old_field, TimescaleDateTimeField) and isinstance(new_field, TimescaleDateTimeField):
+            # migrate existing table to hypertable
+            self._create_hypertable(model, new_field, True)
+        # check if old_field and new_field is type `TimescaleDateTimeField` and `interval` is changed
+        elif isinstance(old_field, TimescaleDateTimeField) and isinstance(new_field, TimescaleDateTimeField):
+            # change chunk-size
+            self._set_chunk_time_interval(model, new_field)

--- a/timescale/db/backends/postgresql/schema.py
+++ b/timescale/db/backends/postgresql/schema.py
@@ -89,7 +89,7 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
         migrate = "true" if should_migrate else "false"
 
         if should_migrate and getattr(settings, "TIMESCALE_MIGRATE_HYPERTABLE_WITH_FRESH_TABLE", False):
-            # TODO migrate with fresh table [https://docs.timescale.com/latest/getting-started/migrating-data#same-db]
+            # TODO migrate with fresh table [https://github.com/schlunsen/django-timescaledb/issues/16]
             raise NotImplementedError()
         else:
             sql = self.sql_add_hypertable.format(

--- a/timescale/db/backends/postgresql/schema.py
+++ b/timescale/db/backends/postgresql/schema.py
@@ -136,6 +136,7 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
             # migrate existing table to hypertable
             self._create_hypertable(model, new_field, True)
         # check if old_field and new_field is type `TimescaleDateTimeField` and `interval` is changed
-        elif isinstance(old_field, TimescaleDateTimeField) and isinstance(new_field, TimescaleDateTimeField):
+        elif isinstance(old_field, TimescaleDateTimeField) and isinstance(new_field, TimescaleDateTimeField) \
+                and old_field.interval != new_field.interval:
             # change chunk-size
             self._set_chunk_time_interval(model, new_field)

--- a/timescale/db/backends/postgresql/schema.py
+++ b/timescale/db/backends/postgresql/schema.py
@@ -39,6 +39,26 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
 
     sql_set_chunk_time_interval = 'SELECT set_chunk_time_interval({table}, interval {interval})'
 
+    def _assert_is_hypertable(self, model):
+        """
+        Assert if the table is a hyper table
+        """
+        table = self.quote_value(model._meta.db_table)
+        error_message = self.quote_value("assert failed - " + table + " should be a hyper table")
+
+        sql = self.sql_assert_is_hypertable.format(table=table, error_message=error_message)
+        self.execute(sql)
+
+    def _assert_is_not_hypertable(self, model):
+        """
+        Assert if the table is not a hyper table
+        """
+        table = self.quote_value(model._meta.db_table)
+        error_message = self.quote_value("assert failed - " + table + " should not be a hyper table")
+
+        sql = self.sql_assert_is_not_hypertable.format(table=table, error_message=error_message)
+        self.execute(sql)
+
     def _drop_primary_key(self, model):
         """
         Hypertables can't partition if the primary key is not
@@ -76,26 +96,6 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
                 table=table, partition_column=partition_column, interval=interval, migrate=migrate
             )
             self.execute(sql)
-
-    def _assert_is_hypertable(self, model):
-        """
-        Assert if the table is a hyper table
-        """
-        table = self.quote_value(model._meta.db_table)
-        error_message = self.quote_value("assert failed - " + table + " should be a hyper table")
-
-        sql = self.sql_assert_is_hypertable.format(table=table, error_message=error_message)
-        self.execute(sql)
-
-    def _assert_is_not_hypertable(self, model):
-        """
-        Assert if the table is not a hyper table
-        """
-        table = self.quote_value(model._meta.db_table)
-        error_message = self.quote_value("assert failed - " + table + " should not be a hyper table")
-
-        sql = self.sql_assert_is_not_hypertable.format(table=table, error_message=error_message)
-        self.execute(sql)
 
     def _set_chunk_time_interval(self, model, field):
         """


### PR DESCRIPTION
updated `TimescaleSchemaEditor` for postgres backend
- extending `postgres.schema.DatabaseSchemaEditor` instead of `postgis.schema.PostGISSchemaEditor`
- rename `drop_primary_key` -> `_drop_primary_key` and `create_hypertable` -> `_create_hypertable`
- `_create_hypertable`: explictly calling `_drop_primary_key`, also added `should_migrate` arg
- `_assert_is_hypertable` and `_assert_is_not_hypertable` methods added and integrated with `_create_hypertable`
- `_set_chunk_time_interval` method added
- override `add_field` and `alter_field` methods of `DatabaseSchemaEditor`

after review
- [x] update README
- [x] apply this changes to "postgis" backend

Closes #13 