### PR TITLE
chore: fixed "You must set output_field" bug

### DIFF
--- a/timescale/db/models/expressions.py
+++ b/timescale/db/models/expressions.py
@@ -6,7 +6,7 @@ from django.db.models.functions.mixins import (
 )
 from django.utils import timezone
 from datetime import timedelta
-
+from timescale.db.models.fields import TimescaleDateTimeField
 
 class Interval(models.Func):
     """
@@ -46,7 +46,8 @@ class TimeBucket(models.Func):
     def __init__(self, expression, interval, *args, **kwargs):
         if not isinstance(interval, models.Value):
             interval = models.Value(interval)
-        super().__init__(interval, expression, *args, **kwargs)
+        output_field = TimescaleDateTimeField(interval=interval)
+        super().__init__(interval, expression, output_field=output_field)
 
 
 class TimeBucketGapFill(models.Func):
@@ -73,4 +74,5 @@ class TimeBucketGapFill(models.Func):
     ):
         if not isinstance(interval, models.Value):
             interval = Interval(interval) / datapoints
-        super().__init__(interval, expression, start, end, *args, **kwargs)
+        output_field = TimescaleDateTimeField(interval=interval)
+        super().__init__(interval, expression, start, end, output_field=output_field)


### PR DESCRIPTION
>>> Metric.timescale.filter(time__range=ranges).time_bucket('time', '1 hour')
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/data/venv/lib/python3.6/site-packages/django/db/models/query.py", line 256, in __repr__
    data = list(self[:REPR_OUTPUT_SIZE + 1])
  File "/data/venv/lib/python3.6/site-packages/django/db/models/query.py", line 280, in __iter__
    self._fetch_all()
  File "/data/venv/lib/python3.6/site-packages/django/db/models/query.py", line 1324, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/data/venv/lib/python3.6/site-packages/django/db/models/query.py", line 109, in __iter__
    for row in compiler.results_iter(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size):
  File "/data/venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1130, in results_iter
    results = self.execute_sql(MULTI, chunked_fetch=chunked_fetch, chunk_size=chunk_size)
  File "/data/venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1162, in execute_sql
    sql, params = self.as_sql()
  File "/data/venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 513, in as_sql
    extra_select, order_by, group_by = self.pre_sql_setup()
  File "/data/venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 55, in pre_sql_setup
    self.setup_query()
  File "/data/venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 46, in setup_query
    self.select, self.klass_info, self.annotation_col_map = self.get_select()
  File "/data/venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 267, in get_select
    sql, params = col.select_format(self, sql, params)
  File "/data/venv/lib/python3.6/site-packages/django/db/models/expressions.py", line 390, in select_format
    print(self.output_field)
  File "/data/venv/lib/python3.6/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/data/venv/lib/python3.6/site-packages/django/db/models/expressions.py", line 265, in output_field
    output_field = self._resolve_output_field()
  File "/data/venv/lib/python3.6/site-packages/django/db/models/expressions.py", line 306, in _resolve_output_field
    source.__class__.__name__,
django.core.exceptions.FieldError: Expression contains mixed types: CharField, TimescaleDateTimeField. You must set output_field.