### PR TITLE
Add support for time_bucket_ng

### DIFF
--- a/example/metrics/tests.py
+++ b/example/metrics/tests.py
@@ -1,3 +1,40 @@
+from timescale.db.models.fields import TimescaleDateTimeField
+from timescale.db.models.expressions import TimeBucketNG
+from metrics.models import Metric
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
+from django.db.models import Avg
+from timescale.db.models.aggregates import First
 
-# Create your tests here.
+
+class TimescaleDBTests(TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_time_bucket_ng(self):
+        timestamp = timezone.now().replace(day=1)
+
+        # datapoints for current month
+        Metric.objects.create(time=timestamp - relativedelta(days=15), temperature=8)
+        Metric.objects.create(time=timestamp - relativedelta(days=10), temperature=10)
+
+        # datapoints for last month
+        Metric.objects.create(time=timestamp - relativedelta(months=1, days=15), temperature=14)
+        Metric.objects.create(time=timestamp - relativedelta(months=1, days=10), temperature=12)
+
+        # get all metrics, monthly aggregated
+        metrics = Metric.timescale.time_bucket_ng('time', '1 month').annotate(Avg('temperature'))
+
+        # verify
+        self.assertEqual(metrics[0]["temperature__avg"], 9.0)
+        self.assertEqual(metrics[1]["temperature__avg"], 13.0)
+
+        # get first entry of the monthly aggregated datapoints
+        metrics = (Metric.timescale
+                   .values(interval_end=TimeBucketNG('time', f'1 month', output_field=TimescaleDateTimeField(interval='1 month')))
+                   .annotate(temperature__first=First('temperature', 'time')))
+
+        # verify
+        self.assertEqual(metrics[0]["temperature__first"], 8.0)
+        self.assertEqual(metrics[1]["temperature__first"], 14.0)

--- a/timescale/db/models/expressions.py
+++ b/timescale/db/models/expressions.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from datetime import timedelta
 from timescale.db.models.fields import TimescaleDateTimeField
 
+
 class Interval(models.Func):
     """
     A helper class to format the interval used by the time_bucket_gapfill function to generate correct timestamps.
@@ -42,6 +43,33 @@ class TimeBucket(models.Func):
 
     function = "time_bucket"
     name = "time_bucket"
+
+    def __init__(self, expression, interval, *args, **kwargs):
+        if not isinstance(interval, models.Value):
+            interval = models.Value(interval)
+        output_field = TimescaleDateTimeField(interval=interval)
+        super().__init__(interval, expression, output_field=output_field)
+
+
+class TimeBucketNG(models.Func):
+    """
+    Implementation of the time_bucket_ng function from Timescale.
+
+    Read more about it here - https://docs.timescale.com/api/latest/hyperfunctions/time_bucket_ng/#timescaledb-experimental-time-bucket-ng
+
+    Response:
+
+    [
+        {'bucket': '2020-12-01T00:00:00+00:00', 'devices': 12},
+        {'bucket': '2020-11-01T00:00:00+00:00', 'devices': 12},
+        {'bucket': '2020-10-01T00:00:00+00:00', 'devices': 12},
+        {'bucket': '2020-09-01T00:00:00+00:00', 'devices': 12},
+    ]
+
+    """
+
+    function = "timescaledb_experimental.time_bucket_ng"
+    name = "timescaledb_experimental.time_bucket_ng"
 
     def __init__(self, expression, interval, *args, **kwargs):
         if not isinstance(interval, models.Value):

--- a/timescale/db/models/managers.py
+++ b/timescale/db/models/managers.py
@@ -1,6 +1,7 @@
 from django.db import models
 from timescale.db.models.querysets import *
 
+
 class TimescaleManager(models.Manager):
     """
     A custom model manager specifically designed around the Timescale
@@ -9,11 +10,14 @@ class TimescaleManager(models.Manager):
 
     def get_queryset(self):
         return TimescaleQuerySet(self.model, using=self._db)
-    
+
     def time_bucket(self, field, interval):
         return self.get_queryset().time_bucket(field, interval)
-    
-    def time_bucket_gapfill(self, field: str, interval: str, start: datetime, end: datetime, datapoints: int=240):
+
+    def time_bucket_ng(self, field, interval):
+        return self.get_queryset().time_bucket_ng(field, interval)
+
+    def time_bucket_gapfill(self, field: str, interval: str, start: datetime, end: datetime, datapoints: int = 240):
         return self.get_queryset().time_bucket_gapfill(field, interval, start, end, datapoints)
 
     def histogram(self, field: str, min_value: float, max_value: float, num_of_buckets: int = 5):

--- a/timescale/db/models/querysets.py
+++ b/timescale/db/models/querysets.py
@@ -1,8 +1,9 @@
 from django.db import models
-from timescale.db.models.expressions import TimeBucket, TimeBucketGapFill
+from timescale.db.models.expressions import TimeBucket, TimeBucketGapFill, TimeBucketNG
 from timescale.db.models.aggregates import Histogram
 from typing import Dict
 from datetime import datetime
+
 
 class TimescaleQuerySet(models.QuerySet):
 
@@ -13,8 +14,16 @@ class TimescaleQuerySet(models.QuerySet):
         if annotations:
             return self.values(bucket=TimeBucket(field, interval)).order_by('-bucket').annotate(**annotations)
         return self.values(bucket=TimeBucket(field, interval)).order_by('-bucket')
-    
-    def time_bucket_gapfill(self, field: str, interval: str, start: datetime, end: datetime, datapoints: int=240):
+
+    def time_bucket_ng(self, field: str, interval: str, annotations: Dict = None):
+        """
+        Wraps the TimescaleDB time_bucket_ng function into a queryset method.
+        """
+        if annotations:
+            return self.values(bucket=TimeBucketNG(field, interval)).order_by('-bucket').annotate(**annotations)
+        return self.values(bucket=TimeBucketNG(field, interval)).order_by('-bucket')
+
+    def time_bucket_gapfill(self, field: str, interval: str, start: datetime, end: datetime, datapoints: int = 240):
         """
         Wraps the TimescaleDB time_bucket_gapfill function into a queryset method.
         """


### PR DESCRIPTION
PR to add the experimental `time_bucket_ng` functionality from timescaledb 2.4. 
The code is mostly a copy from the existing`time_bucket` class & functions and adds a basic test case for the example django project to show the usage. Could you maybe have a look at it and tell me what you think?

resolves #29 

thx, Christian