### PR TITLE
Include schema name when checking for the existence of a hypertable 

### DIFF
--- a/timescale/db/backends/postgresql/schema.py
+++ b/timescale/db/backends/postgresql/schema.py
@@ -5,7 +5,8 @@ from timescale.db.models.fields import TimescaleDateTimeField
 
 
 class TimescaleSchemaEditor(DatabaseSchemaEditor):
-    sql_is_hypertable = 'SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = {table}'
+    sql_is_hypertable = '''SELECT * FROM timescaledb_information.hypertables 
+    WHERE hypertable_name = {table}{extra_condition}'''
 
     sql_assert_is_hypertable = (
             'DO $do$ BEGIN '
@@ -39,6 +40,8 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
 
     sql_set_chunk_time_interval = 'SELECT set_chunk_time_interval({table}, interval {interval})'
 
+    sql_hypertable_is_in_schema = '''hypertable_schema = {schema_name}'''
+
     def _assert_is_hypertable(self, model):
         """
         Assert if the table is a hyper table
@@ -46,7 +49,11 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
         table = self.quote_value(model._meta.db_table)
         error_message = self.quote_value("assert failed - " + table + " should be a hyper table")
 
-        sql = self.sql_assert_is_hypertable.format(table=table, error_message=error_message)
+        extra_condition = self._get_extra_condition()
+
+        sql = self.sql_assert_is_hypertable.format(table=table, error_message=error_message,
+                                                   extra_condition=extra_condition)
+
         self.execute(sql)
 
     def _assert_is_not_hypertable(self, model):
@@ -56,7 +63,11 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
         table = self.quote_value(model._meta.db_table)
         error_message = self.quote_value("assert failed - " + table + " should not be a hyper table")
 
-        sql = self.sql_assert_is_not_hypertable.format(table=table, error_message=error_message)
+        extra_condition = self._get_extra_condition()
+
+        sql = self.sql_assert_is_not_hypertable.format(table=table, error_message=error_message,
+                                                       extra_condition=extra_condition)
+
         self.execute(sql)
 
     def _drop_primary_key(self, model):
@@ -140,3 +151,15 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
                 and old_field.interval != new_field.interval:
             # change chunk-size
             self._set_chunk_time_interval(model, new_field)
+
+    def _get_extra_condition(self):
+        extra_condition = ''
+
+        try:
+            if self.connection.schema_name:
+                schema_name = self.quote_value(self.connection.schema_name)
+                extra_condition = ' AND ' + self.sql_hypertable_is_in_schema.format(schema_name=schema_name)
+        except:
+            pass
+
+        return extra_condition


### PR DESCRIPTION
In addition to `django-timescaledb` I'm using the `django-tenants` library which creates a separate schema for each tenant where the tables of that tenant will live.

If I have a hypertable model that should be created for each tenant, I'll run into an error when I create my second tenant, because a hypertable for that model already exists _but in a different schema_, and the sql statement to check for the existence of a hypertable ignores the "hypertable_schema" column. See image:

![image](https://user-images.githubusercontent.com/13931997/150660110-f8c17dff-70c7-4205-8a94-a32370a2bea6.png)

Notice how there are two hypertables with the same name, but they're in different schemas, which should be totally fine. They won't affect each other at all.

So I included the `hypertable_schema` column in the sql statements that check for the existence of hypertable.

----

This issue is not directly related to the `django-timescaledb` library since it only applies for someone who also uses the other library `django-tenants`. I don't know how you'd feel about merging this code in, but I thought I'd create the PR anyway and leave it up to you to decide.