### PR TITLE
Update README.md to include a simple "write data" howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ class Metric(models.Model):
 
 The name of the field is important as Timescale specific feratures require this as a property of their functions.
 
+### Writing Data
+
+Writing data is done though the normal Django ORM.
+
+```python
+    Metric.objects.create(temperature=5.2, time=now())
+```
+
 ### Reading Data
 
 "TimescaleDB hypertables are designed to behave in the same manner as PostgreSQL database tables for reading data, using standard SQL commands."


### PR DESCRIPTION
May I suggest adding a simple "write data" section before the "read data" section to the README - I think having a super-simple "write data, read data" loop is very logical and shows you the true smarts of this great library. 

Currently, you have to look at the [tests of the example project](https://github.com/jamessewell/django-timescaledb/blob/main/example/metrics/tests.py#L19) to confirm how to do this. At least that's how I found out about 'how to write'.

Thanks for your consideration, and the great project!